### PR TITLE
Sort input file list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,7 @@ else:
         libraries.append("iconv")
 
 # Extensions
+sources.sort()
 extensions = [Extension("pyreadstat.pyreadstat",
                     sources=["pyreadstat/pyreadstat" + ext] + sources,
                     # this dot here is important for cython to find the pxd files


### PR DESCRIPTION
Sort input file list
so that `_readstat_parser.so` builds in a reproducible way
in spite of indeterministic filesystem readdir order
and missing https://github.com/python/cpython/pull/12341

See https://reproducible-builds.org/ for why this is good.

This PR was done while working on reproducible builds for openSUSE.