### PR TITLE
Fix PyUnicode_AsWideCharString signature

### DIFF
--- a/pyreadstat/_readstat_parser.pxd
+++ b/pyreadstat/_readstat_parser.pxd
@@ -131,7 +131,7 @@ IF PY_MAJOR_VERSION >2:
             pass
             
     cdef extern from "Python.h":
-        wchar_t* PyUnicode_AsWideCharString(object, Py_ssize_t *)
+        wchar_t* PyUnicode_AsWideCharString(object, Py_ssize_t *) except NULL
             
     # these ones would make the c file produced by cython not portable between windows and unix
     # therefore the conditional including of the libraries is handled in C


### PR DESCRIPTION
* PyUnicode_AsWideCharString may raise ValueError or MemoryError https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_AsWideCharString
* https://cython.readthedocs.io/en/stable/src/tutorial/clibraries.html#handling-errors

# Correct:
```c
static PyObject *__pyx_pf_7correct_foo(CYTHON_UNUSED PyObject *__pyx_self) {
  PyObject *__pyx_r = NULL;
  __Pyx_RefNannyDeclarations
  wchar_t *__pyx_t_1;
  int __pyx_lineno = 0;
  const char *__pyx_filename = NULL;
  int __pyx_clineno = 0;
  __Pyx_RefNannySetupContext("foo", 0);

  /* "correct.pyx":7
 * 
 * def foo():
 *     PyUnicode_AsWideCharString("", NULL)             # <<<<<<<<<<<<<<
 */
  __pyx_t_1 = PyUnicode_AsWideCharString(__pyx_kp_s_, NULL); if (unlikely(__pyx_t_1 == ((wchar_t *)NULL))) __PYX_ERR(0, 7, __pyx_L1_error)

  /* "correct.pyx":6
 *     wchar_t* PyUnicode_AsWideCharString(object, Py_ssize_t *) except NULL
 * 
 * def foo():             # <<<<<<<<<<<<<<
 *     PyUnicode_AsWideCharString("", NULL)
 */

  /* function exit code */
  __pyx_r = Py_None; __Pyx_INCREF(Py_None);
  goto __pyx_L0;
  __pyx_L1_error:;
  __Pyx_AddTraceback("correct.foo", __pyx_clineno, __pyx_lineno, __pyx_filename);
  __pyx_r = NULL;
  __pyx_L0:;
  __Pyx_XGIVEREF(__pyx_r);
  __Pyx_RefNannyFinishContext();
  return __pyx_r;
}
```

# Wrong:
```c
static PyObject *__pyx_pf_5wrong_foo(CYTHON_UNUSED PyObject *__pyx_self) {
  PyObject *__pyx_r = NULL;
  __Pyx_RefNannyDeclarations
  __Pyx_RefNannySetupContext("foo", 0);

  /* "wrong.pyx":7
 * 
 * def foo():
 *     PyUnicode_AsWideCharString("", NULL)             # <<<<<<<<<<<<<<
 */
  (void)(PyUnicode_AsWideCharString(__pyx_kp_s_, NULL));

  /* "wrong.pyx":6
 *     wchar_t* PyUnicode_AsWideCharString(object, Py_ssize_t *)
 * 
 * def foo():             # <<<<<<<<<<<<<<
 *     PyUnicode_AsWideCharString("", NULL)
 */

  /* function exit code */
  __pyx_r = Py_None; __Pyx_INCREF(Py_None);
  __Pyx_XGIVEREF(__pyx_r);
  __Pyx_RefNannyFinishContext();
  return __pyx_r;
}
```