### PR TITLE
Add Github workflows for building, testing and linting

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,24 @@
+name: Build and Test
+
+on: [push, pull_request]
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Install pyreadstat
+        run: python setup.py install
+      - name: Run tests
+        run: python tests/test_basic.py

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,24 @@
+name: Lint with flake8
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.10'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip flake8
+        pip install -r requirements.txt
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+cython
+pandas


### PR DESCRIPTION
This PR adds some Github workflows that are triggered on pushing and pull request events.

The lint check uses `flake8` to analyze the code. It currently only prints the output and should only fail if syntax errors are detected.

The other check builds the project in ubuntu and runs the tests `test_basic.py`.
I have also tried to add a workflow to build in Windows (using https://github.com/conda-incubator/setup-miniconda and the instructions on how to compile this project under Windows) but wasn't successful.