### PR TITLE
Upgrade GitHub actions

### DIFF
--- a/.github/actions/windows_actions/action.yml
+++ b/.github/actions/windows_actions/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout libiconv
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: kiyolee/libiconv-win-build
         ref: dff1030d222ba934e0f4a9cdab9c34134f072f68 # v1.18
@@ -13,7 +13,7 @@ runs:
         persist-credentials: false
 
     - name: Checkout zlib
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: kiyolee/zlib-win-build
         ref: 30623e05e64fe4b97f2073ddaf8d3ba0e99d7249
@@ -21,7 +21,7 @@ runs:
         persist-credentials: false
 
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v2
+      uses: microsoft/setup-msbuild@v3
 
     - name: Build libiconv
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 


### PR DESCRIPTION
The build currently generates the following warning:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-python@v5, microsoft/setup-msbuild@v2. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

The action `microsoft/setup-msbuild@v2` is only listed in the warning for the Windows build while the other two are listed for all builds.

The proposed upgrades of the actions resolve the issue.