### PR TITLE
Address compilation warnings

### DIFF
--- a/pyreadstat/_readstat_parser.pyx
+++ b/pyreadstat/_readstat_parser.pyx
@@ -293,7 +293,7 @@ cdef object convert_readstat_to_python_value(readstat_value_t value, int index, 
     cdef py_file_format file_format
     cdef object result
 
-    cdef char * c_str_value
+    cdef const char * c_str_value
     cdef str py_str_value
     cdef int8_t c_int8_value
     cdef int16_t c_int16_value
@@ -385,15 +385,15 @@ cdef int handle_metadata(readstat_metadata_t *metadata, void *ctx) except READST
     cdef int var_count, obs_count, mr_len
     cdef  data_container dc = <data_container> ctx
     #cdef object row
-    cdef char * flabel_orig
-    cdef char * fencoding_orig
+    cdef const char * flabel_orig
+    cdef const char * fencoding_orig
     cdef str flabel, fencoding
     cdef bint metaonly
-    cdef char * table
+    cdef const char * table
     cdef int ctime
     cdef int mtime
     cdef int i = 0
-    cdef mr_set_t * mr_sets_orig
+    cdef const mr_set_t * mr_sets_orig
     cdef dict mr_sets = {}
     cdef str name
     cdef list variable_list = []
@@ -468,9 +468,9 @@ cdef int handle_variable(int index, readstat_variable_t *variable,
     if any.
     """
 
-    cdef char * var_name, 
-    cdef char * var_label
-    cdef char * var_format
+    cdef const char * var_name, 
+    cdef const char * var_label
+    cdef const char * var_format
     cdef str col_name, col_label, label_name, col_format_original, output_format
     cdef py_datetime_format col_format_final
     cdef readstat_type_t var_type
@@ -742,7 +742,7 @@ cdef int handle_value_label(char *val_labels, readstat_value_t value, char *labe
 
     cdef  data_container dc = <data_container> ctx
 
-    cdef char * c_str_value
+    cdef const char * c_str_value
     cdef str py_str_value
     cdef int8_t c_int8_value
     cdef int16_t c_int16_value
@@ -905,7 +905,7 @@ cdef void check_exit_status(readstat_error_t retcode) except *:
     transforms a readstat exit status to a python error if status is not READSTAT OK
     """
 
-    cdef char * err_readstat
+    cdef const char * err_readstat
     cdef str err_message
     if retcode != READSTAT_OK:
         err_readstat = readstat_error_message(retcode)
@@ -943,7 +943,7 @@ cdef void run_readstat_parser(char * filename, data_container data, py_file_exte
     metaonly = data.metaonly
     ctx = <void *>data
     
-    #readstat_error_t error = READSTAT_OK;
+    error = READSTAT_OK;
     parser = readstat_parser_init()
     metadata_handler = <readstat_metadata_handler> handle_metadata
     variable_handler = <readstat_variable_handler> handle_variable

--- a/pyreadstat/_readstat_writer.pyx
+++ b/pyreadstat/_readstat_writer.pyx
@@ -146,7 +146,8 @@ cdef double convert_datetimelike_to_number(dst_file_format file_format, pywriter
     converts a datime like python/pandas object to a float
     """
 
-    cdef double offset_days, tstamp
+    cdef double offset_days
+    cdef double tstamp = 0
 
     if file_format == FILE_FORMAT_SAV or file_format == FILE_FORMAT_POR:
         offset_days = spss_offset_days
@@ -573,18 +574,6 @@ cdef ssize_t write_bytes(const void *data, size_t _len, void *ctx) noexcept:
         return _write(fd, data, _len)
     else:
         return write(fd, data, _len)
-
-cdef void _check_exit_status(readstat_error_t retcode) except *:
-    """
-    transforms a readstat exit status to a python error if status is not READSTAT OK
-    """
-
-    cdef char * err_readstat
-    cdef str err_message
-    if retcode != READSTAT_OK:
-        err_readstat = readstat_error_message(retcode)
-        err_message = <str> err_readstat
-        raise ReadstatError(err_message)
 
 cdef int open_file(bytes filename_bytes):
 


### PR DESCRIPTION
Compiling the code with

```
pip install -v .
```

on Ubuntu produces a lot of warnings. Most of them come from ReadStat but not all of them.

Below, I'll post the relevant section of the output of

```
pip install -v . 2>&1 | grep -A3 pyreadstat
```

This PR addresses these particular issues. Most of the warnings are about missing `const` qualifiers but there are also two potentially uninitialized variables and an unused function.

```
  pyreadstat/_readstat_parser.c: In function ‘__pyx_f_10pyreadstat_16_readstat_parser_convert_readstat_to_python_value’:
  pyreadstat/_readstat_parser.c:7739:25: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
   7739 |     __pyx_v_c_str_value = readstat_string_value(__pyx_v_value);
        |                         ^
  pyreadstat/_readstat_parser.c: In function ‘__pyx_f_10pyreadstat_16_readstat_parser_handle_metadata’:
  pyreadstat/_readstat_parser.c:8608:24: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
   8608 |   __pyx_v_mr_sets_orig = readstat_get_multiple_response_sets(__pyx_v_metadata);
        |                        ^
  pyreadstat/_readstat_parser.c:8899:23: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
   8899 |   __pyx_v_flabel_orig = readstat_get_file_label(__pyx_v_metadata);
        |                       ^
  pyreadstat/_readstat_parser.c:8908:26: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
   8908 |   __pyx_v_fencoding_orig = readstat_get_file_encoding(__pyx_v_metadata);
        |                          ^
  pyreadstat/_readstat_parser.c:9055:17: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
   9055 |   __pyx_v_table = readstat_get_table_name(__pyx_v_metadata);
        |                 ^
  pyreadstat/_readstat_parser.c: In function ‘__pyx_f_10pyreadstat_16_readstat_parser_handle_variable’:
  pyreadstat/_readstat_parser.c:9250:20: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
   9250 |   __pyx_v_var_name = readstat_variable_get_name(__pyx_v_variable);
        |                    ^
  pyreadstat/_readstat_parser.c:9621:21: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
   9621 |   __pyx_v_var_label = readstat_variable_get_label(__pyx_v_variable);
        |                     ^
  pyreadstat/_readstat_parser.c:9691:22: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
   9691 |   __pyx_v_var_format = readstat_variable_get_format(__pyx_v_variable);
        |                      ^
  pyreadstat/_readstat_parser.c: In function ‘__pyx_f_10pyreadstat_16_readstat_parser_handle_value_label’:
  pyreadstat/_readstat_parser.c:12029:27: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  12029 |       __pyx_v_c_str_value = readstat_string_value(__pyx_v_value);
        |                           ^
  pyreadstat/_readstat_parser.c: In function ‘__pyx_f_10pyreadstat_16_readstat_parser_check_exit_status’:
  pyreadstat/_readstat_parser.c:13268:26: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  13268 |     __pyx_v_err_readstat = readstat_error_message(__pyx_v_retcode);
        |                          ^
  pyreadstat/_readstat_parser.c: In function ‘__pyx_f_10pyreadstat_16_readstat_parser_run_readstat_parser’:
  pyreadstat/_readstat_parser.c:13941:5: warning: ‘__pyx_v_error’ may be used uninitialized [-Wmaybe-uninitialized]
  13941 |     __pyx_f_10pyreadstat_16_readstat_parser_check_exit_status(__pyx_v_error); if (unlikely(PyErr_Occurred())) __PYX_ERR(0, 1009, __pyx_L1_error)
        |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  pyreadstat/_readstat_parser.c:13359:20: note: ‘__pyx_v_error’ was declared here
  13359 |   readstat_error_t __pyx_v_error;
        |                    ^~~~~~~~~~~~~
--
  pyreadstat/_readstat_writer.c: In function ‘__pyx_f_10pyreadstat_16_readstat_writer__check_exit_status’:
  pyreadstat/_readstat_writer.c:11028:26: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  11028 |     __pyx_v_err_readstat = readstat_error_message(__pyx_v_retcode);
        |                          ^
  pyreadstat/_readstat_writer.c: At top level:
  pyreadstat/_readstat_writer.c:10997:13: warning: ‘__pyx_f_10pyreadstat_16_readstat_writer__check_exit_status’ defined but not used [-Wunused-function]
  10997 | static void __pyx_f_10pyreadstat_16_readstat_writer__check_exit_status(readstat_error_t __pyx_v_retcode) {
        |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  pyreadstat/_readstat_writer.c: In function ‘__pyx_f_10pyreadstat_16_readstat_writer_convert_datetimelike_to_number’:
  pyreadstat/_readstat_writer.c:5016:20: warning: ‘__pyx_v_tstamp’ may be used uninitialized [-Wmaybe-uninitialized]
   5016 |     __pyx_v_tstamp = (__pyx_v_tstamp + __pyx_v_offset_secs);
        |     ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  pyreadstat/_readstat_writer.c:4850:10: note: ‘__pyx_v_tstamp’ was declared here
   4850 |   double __pyx_v_tstamp;
        |          ^~~~~~~~~~~~~~
```